### PR TITLE
Avoid relying on Node’s internals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const builtinModules = require('module').builtinModules;
+
 const blacklist = [
 	'freelist',
 	'sys'
 ];
 
-module.exports = Object.keys(process.binding('natives'))
+module.exports = (builtinModules || Object.keys(process.binding('natives')))
 	.filter(x => !/^_|^internal|\//.test(x) && blacklist.indexOf(x) === -1)
 	.sort();

--- a/index.js
+++ b/index.js
@@ -7,5 +7,5 @@ const blacklist = [
 ];
 
 module.exports = (builtinModules || Object.keys(process.binding('natives')))
-	.filter(x => !/^_|^internal|\//.test(x) && blacklist.indexOf(x) === -1)
+	.filter(x => !/^_|^(internal|v8|node-inspect)\/|\//.test(x) && blacklist.indexOf(x) === -1)
 	.sort();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const builtinModules = require('module').builtinModules;
 
 const blacklist = [


### PR DESCRIPTION
`process.binding()` is not a public API, and should
not be used.

Luckily, Node recently introduced an API that does
exactly what builtin-modules needs:
https://nodejs.org/api/modules.html#modules_module_builtinmodules

So use that instead and keep the old path as a fallback.